### PR TITLE
New way of activating conda environments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,11 @@ free to give it a go::
         # if you want to download and install IDEs like Spyder or RStudio with this installation, please use:
            --ide
 
-        # once the installation is finished, enable the conda environment as requested by the installation script:
-        source </full/path/to/folder/without/trailing/slash>/conda-install/bin/activate cgat-f
+        # once the installation is finished, enable the conda environment as requested by the installation script
+        # NB: you probably want to automate this by adding the instructions below to your .bashrc
+        source </full/path/to/folder/without/trailing/slash>/conda-install/etc/profile.d/conda.sh cgat-f
+        conda activate base
+        conda activate cgat-f
 
         # finally, please run the cgatflow command-line tool to check the installation:
         cgatflow --help

--- a/doc/InstallingPipelines.rst
+++ b/doc/InstallingPipelines.rst
@@ -41,7 +41,10 @@ Here are the steps::
            --ide
 
         # once the installation is finished, enable the conda environment as requested by the installation script:
-        source </full/path/to/folder/without/trailing/slash>/conda-install/bin/activate cgat-f
+        # NB: you probably want to automate this by adding the instructions below to your .bashrc
+        source </full/path/to/folder/without/trailing/slash>/conda-install/etc/profile.d/conda.sh cgat-f
+        conda activate base
+        conda activate cgat-f
 
         # finally, please run the cgatflow command-line tool to check the installation:
         cgatflow --help

--- a/install-CGAT-tools.sh
+++ b/install-CGAT-tools.sh
@@ -396,10 +396,13 @@ if [[ -z ${TRAVIS_INSTALL} ]] ; then
       echo " The code successfully installed!"
       echo
       echo " To activate the CGAT environment type: "
-      echo " $ source $CONDA_INSTALL_DIR/bin/activate $CONDA_INSTALL_ENV"
+      echo " $ source $CONDA_INSTALL_DIR/etc/profile.d/conda.sh $CONDA_INSTALL_ENV"
+      echo " $ conda activate base"
+      echo " $ conda activate $CONDA_INSTALL_ENV"
+      [[ $INSTALL_PRODUCTION ]] && echo " cgatflow --help"
       echo
       echo " To deactivate the environment, use:"
-      echo " $ source deactivate"
+      echo " $ conda deactivate"
       echo
    fi # if-$ conda create
 

--- a/install-CGAT-tools.sh
+++ b/install-CGAT-tools.sh
@@ -850,6 +850,13 @@ if [[ ${RELEASE_PIPELINES} -ne 0 ]] ; then
 }
 
 
+# test whether a C/C++ compiler is available
+test_compilers() {
+   which gcc &> /dev/null || report_error " C compiler not found "
+   which g++ &> /dev/null || report_error " C++ compiler not found "
+}
+
+
 # function to display help message
 help_message() {
 echo
@@ -893,6 +900,8 @@ exit 1
 } # help_message
 
 # the script starts here
+
+test_compilers
 
 if [[ $# -eq 0 ]] ; then
 


### PR DESCRIPTION
Due to the new way we use conda environments in the code, and a change in the way that conda environments are [handled](https://github.com/conda/conda/blob/master/CHANGELOG.md#440-2017-12-20), the docs need updating.

Also, the GCC package in conda [seems](https://github.com/ContinuumIO/anaconda-issues/issues/5191) to be deprecated and therefore we need to rely now on a local C/C++ compiler on the target machine. Added a test to check for compilers before performing the installation. Removed `gcc` packages in [here
](https://github.com/cgat-developers/cgat-flow/compare/122752d1d380...e7f4a3a166bc)