### PR TITLE
Fixes for

### DIFF
--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -1861,12 +1861,12 @@ for x in P.as_list(PARAMS["mappers"]):
 def mapping():
     ''' dummy task to define upstream mapping tasks'''
 
+
 if "merge_pattern_input" in PARAMS and PARAMS["merge_pattern_input"]:
     if "merge_pattern_output" not in PARAMS or \
        not PARAMS["merge_pattern_output"]:
         raise ValueError(
             "no output pattern 'merge_pattern_output' specified")
-
 
     @collate(MAPPINGTARGETS,
              regex("%s\.([^.]+)\.bam" % PARAMS["merge_pattern_input"].strip()),

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -1861,15 +1861,15 @@ for x in P.as_list(PARAMS["mappers"]):
 def mapping():
     ''' dummy task to define upstream mapping tasks'''
 
-
 if "merge_pattern_input" in PARAMS and PARAMS["merge_pattern_input"]:
     if "merge_pattern_output" not in PARAMS or \
        not PARAMS["merge_pattern_output"]:
         raise ValueError(
             "no output pattern 'merge_pattern_output' specified")
 
+
     @collate(MAPPINGTARGETS,
-             regex("%s\.([^.]+).bam" % PARAMS["merge_pattern_input"].strip()),
+             regex("%s\.([^.]+)\.bam" % PARAMS["merge_pattern_input"].strip()),
              # the last expression counts number of groups in pattern_input
              r"%s.\%i.bam" % (PARAMS["merge_pattern_output"].strip(),
                               PARAMS["merge_pattern_input"].count("(") + 1),
@@ -1894,8 +1894,8 @@ if "merge_pattern_input" in PARAMS and PARAMS["merge_pattern_input"]:
             E.info(
                 "%(outfile)s: only one file for merging - creating "
                 "softlink" % locals())
-            P.clone(infiles[0], outfile)
-            P.clone(infiles[0] + ".bai", outfile + ".bai")
+            os.symlink(infiles[0], outfile)
+            os.symlink(infiles[0] + ".bai", outfile + ".bai")
             return
 
         infiles = " ".join(infiles)
@@ -1907,9 +1907,10 @@ if "merge_pattern_input" in PARAMS and PARAMS["merge_pattern_input"]:
 
     MAPPINGTARGETS = MAPPINGTARGETS + [mergeBAMFiles]
 
+    @follows(mergeBAMFiles)
     @collate(countReads,
              regex("%s.nreads" % PARAMS["merge_pattern_input"]),
-             r"nreads.dir/%s.nreads" % PARAMS["merge_pattern_output"],
+             r"%s.nreads" % PARAMS["merge_pattern_output"],
              )
     def mergeReadCounts(infiles, outfile):
         '''merge read counts files from the same experiment using


### PR DESCRIPTION
Fixed errors in pipeline mapping
1. os.symlink instead of P.clone
2. mergeBAMFiles was not being called by "full"
3. removed nreads.dir/nreads.dir doubling up of subdirectories