### PR TITLE
updated mapping to make tophat run

### DIFF
--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -2178,7 +2178,7 @@ class Tophat(Mapper):
 
         if nfiles == 1:
             infiles = ",".join([x[0] for x in infiles])
-            statement.append('''
+            statement = '''
             %(executable)s --output-dir %(tmpdir_tophat)s
                    --num-threads %%(tophat_threads)i
                    --library-type %%(tophat_library_type)s
@@ -2187,7 +2187,7 @@ class Tophat(Mapper):
                    %(index_prefix)s
                    %(infiles)s
                    >> %(outfile)s.log 2>&1 ;
-            ''' % locals())
+            ''' % locals()
 
         elif nfiles == 2:
             # this section works both for paired-ended fastq files
@@ -2195,7 +2195,7 @@ class Tophat(Mapper):
             infiles1 = ",".join([x[0] for x in infiles])
             infiles2 = ",".join([x[1] for x in infiles])
 
-            statement.append('''
+            statement = '''
             %(executable)s --output-dir %(tmpdir_tophat)s
                    --mate-inner-dist %%(tophat_mate_inner_dist)i
                     --num-threads %%(tophat_threads)i
@@ -2205,7 +2205,7 @@ class Tophat(Mapper):
                    %(index_prefix)s
                    %(infiles1)s %(infiles2)s
                    >> %(outfile)s.log 2>&1 ;
-            ''' % locals())
+            ''' % locals()
         elif nfiles == 4:
             # this section works both for paired-ended fastq files
             # in color space mapping (separate quality file)
@@ -2215,7 +2215,7 @@ class Tophat(Mapper):
             infiles3 = ",".join([x[2] for x in infiles])
             infiles4 = ",".join([x[3] for x in infiles])
 
-            statement.append('''%(executable)s
+            statement = '''%(executable)s
                    --output-dir %(tmpdir_tophat)s
                    --mate-inner-dist %%(tophat_mate_inner_dist)i
                    --num-threads %%(tophat_threads)i
@@ -2226,7 +2226,7 @@ class Tophat(Mapper):
                    %(infiles1)s %(infiles2)s
                    %(infiles3)s %(infiles4)s
                    >> %(outfile)s.log 2>&1 ;
-            ''' % locals())
+            ''' % locals()
 
         else:
             raise ValueError("unexpected number reads to map: %i " % nfiles)

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -852,7 +852,7 @@ def mapReadsWithTophat(infiles, outfile):
             " --transcriptome-index=%s -n 2" % prefix
 
     statement = m.build((infile,), outfile)
-    P.run(statement)
+    P.run(statement, job_condaenv="tophat2")
 
 
 @active_if(SPLICED_MAPPING)

--- a/CGATPipelines/pipeline_mapping.py
+++ b/CGATPipelines/pipeline_mapping.py
@@ -585,7 +585,7 @@ def buildReferenceTranscriptome(infile, outfile):
     gtf_to_fasta %(gtf_file)s %(genome_file)s %(outfile)s;
     samtools faidx %(outfile)s
     '''
-    P.run(statement)
+    P.run(statement, job_condaenv="tophat2")
 
     dest = P.snip(os.path.abspath(gtf_file), ".gtf") + ".gff"
     if not os.path.exists(dest):

--- a/conda/environments/pipelines-tophat2.yml
+++ b/conda/environments/pipelines-tophat2.yml
@@ -8,3 +8,4 @@ channels:
 
 dependencies:
 - tophat=2.1.1
+- samtools=1.7


### PR DESCRIPTION
@sebastian-luna-valero this commit fixes a problem when running tophat or tophat2. The genome build does not work because the conda environment does not specify tophat2. In addition to this, samtools needs to be included as part of the tophat2 conda environment.