### PR TITLE
Updated PipelineMapping.py for Sratoolkit

### DIFF
--- a/CGATPipelines/PipelineMapping.py
+++ b/CGATPipelines/PipelineMapping.py
@@ -557,7 +557,7 @@ class SequenceCollectionProcessor(object):
                     repo, acc = line.strip().split("\t")[:2]
                     if repo == "SRA":
                         statement.append(Sra.prefetch(acc))
-                        f, format = Sra.peek(acc)
+                        f, format, _ = Sra.peek(acc)
                         statement.append(Sra.extract(acc, tmpdir_fastq))
 
                         extracted_files = ["%s/%s" % (


### PR DESCRIPTION
Fix for error:

 `File "/cgat/cgat-flow/CGATPipelines/PipelineMapping.py", line 560, in preprocess \
                                                 f, format = Sra.peek(acc) \
                                             ValueError: too many values to unpack (expected 2) \`