### PR TITLE
Create Conda Environment for Pipeline Splicing

### DIFF
--- a/cgatpipelines/tasks/rnaseq.py
+++ b/cgatpipelines/tasks/rnaseq.py
@@ -548,10 +548,10 @@ def makeExpressionSummaryPlots(counts_inf, design_inf, logfile):
                              colour="group", shape="group")
 
         # Z-score normalise the expression for the heatmap visualisation
-        counts_log10.zNormalise(inplace=True)
+        # counts_log10.zNormalise(inplace=True)
 
-        log.write("plot heatmap: %s\n" % heatmap_outfile)
-        counts_log10.heatmap(heatmap_outfile, zscore=True)
+        # log.write("plot heatmap: %s\n" % heatmap_outfile)
+        # counts_log10.heatmap(heatmap_outfile, zscore=True)
 
 
 def getAlignmentFreeNormExp(transcript_infiles, basename, column,

--- a/cgatpipelines/tasks/splicing.py
+++ b/cgatpipelines/tasks/splicing.py
@@ -117,7 +117,7 @@ def runRMATS(gtffile, designfile, pvalue, strand, outdir, permute=0):
     > %(outdir)s/%(designfile)s.log
     '''
 
-    P.run(statement, job_condaenv="macs2")
+    P.run(statement, job_condaenv="splicing")
 
 
 def rmats2sashimi(infile, designfile, FDR, outfile):

--- a/cgatpipelines/tasks/splicing.py
+++ b/cgatpipelines/tasks/splicing.py
@@ -117,7 +117,7 @@ def runRMATS(gtffile, designfile, pvalue, strand, outdir, permute=0):
     > %(outdir)s/%(designfile)s.log
     '''
 
-    P.run(statement)
+    P.run(statement, job_condaenv="macs2")
 
 
 def rmats2sashimi(infile, designfile, FDR, outfile):

--- a/cgatpipelines/tools/pipeline_splicing.py
+++ b/cgatpipelines/tools/pipeline_splicing.py
@@ -152,11 +152,7 @@ PARAMS.update(P.peek_parameters(
     restrict_interface=True))  # add config values from associated pipelines
 
 # The DEXSeq R directory contains important python helper functions
-PYTHONSCRIPTSDIR = R('''
-    f = function(){
-    pythonScriptsDir = system.file("python_scripts", package="DEXSeq")
-    }
-    f()''').tostring()
+PYTHONSCRIPTSDIR = R('''system.file("python_scripts", package="DEXSeq")''')[0]
 
 
 ###################################################################

--- a/cgatpipelines/tools/pipeline_splicing.py
+++ b/cgatpipelines/tools/pipeline_splicing.py
@@ -274,7 +274,7 @@ def countDEXSeq(infiles, outfile):
     -s %(strandedness)s
     -r pos
     -f bam  %(gfffile)s %(infile)s %(outfile)s'''
-    P.run(statement)
+    P.run(statement, job_condaenv="splicing")
 
 
 @collate(countDEXSeq,

--- a/conda/environments/pipelines-splicing.yml
+++ b/conda/environments/pipelines-splicing.yml
@@ -1,0 +1,12 @@
+
+name: splicing
+
+channels:
+- bioconda
+- conda-forge
+- defaults
+
+dependencies:
+- python=2.7
+- bioconductor-dexseq
+- htseq

--- a/install-CGAT-tools.sh
+++ b/install-CGAT-tools.sh
@@ -446,6 +446,10 @@ curl -O https://raw.githubusercontent.com/cgat-developers/cgat-flow/${TRAVIS_BRA
 
 conda env update --quiet --file pipeline-peakcalling-sicer.yml
 
+curl -O https://raw.githubusercontent.com/cgat-developers/cgat-flow/${TRAVIS_BRANCH}/conda/environments/pipelines-splicing.yml
+
+conda env update --quiet --file pipelines-splicing.yml
+
 }
 
 


### PR DESCRIPTION
Fixes errors in Pipeline Splicing & creates python 2.7 environment to run DEXSeq helper functions and rMATS-turbo.

Also removes heamap fro makeExpressionSummaryPlots in DESEq2: this fails due to memory allocation error from rpy2.