### PR TITLE
STAR cannot using a named pipe when doing 2pass mapping as it require…

### DIFF
--- a/cgatpipelines/tasks/mapping.py
+++ b/cgatpipelines/tasks/mapping.py
@@ -2754,7 +2754,14 @@ class STAR(Mapper):
         logfile = ("%sLog.final.out") % (P.snip(outfile, ".star.bam"))
 
         if nfiles == 1:
-            infiles = "<( zcat %s )" % " ".join([x[0] for x in infiles])
+
+            if infiles[0].endswith(".gz"):
+                compress_option = "--readFilesCommand zcat"
+            else:
+                compress_option = ""
+                
+            infiles = " ".join([x[0] for x in infiles])
+
             statement = '''
             %(executable)s
             --runMode alignReads
@@ -2764,6 +2771,7 @@ class STAR(Mapper):
             --outStd SAM
             --outSAMunmapped Within
             %%(star_options)s
+            %(compress_option)s
             --readFilesIn %(infiles)s
             | samtools view -bS -
             > %(tmpdir)s/%(track)s.bam

--- a/cgatpipelines/tasks/mapping.py
+++ b/cgatpipelines/tasks/mapping.py
@@ -2752,10 +2752,10 @@ class STAR(Mapper):
         index_prefix = "%(genome)s"
 
         logfile = ("%sLog.final.out") % (P.snip(outfile, ".star.bam"))
-
         if nfiles == 1:
 
-            if infiles[0].endswith(".gz"):
+            
+            if str(infiles[0][0]).endswith(".gz"):
                 compress_option = "--readFilesCommand zcat"
             else:
                 compress_option = ""


### PR DESCRIPTION
…s a second pass over the file.

Instead we must use --readFilesCommand.

This was already the case for paried-end data, but not for single end.

This commit fixes that.

Fixes #79.
