### PR TITLE
Small bug fix in summarizeFastQC within pipeline_readqc

### DIFF
--- a/cgatpipelines/tools/pipeline_readqc.py
+++ b/cgatpipelines/tools/pipeline_readqc.py
@@ -369,7 +369,7 @@ def summarizeFastQC(infiles, outfiles):
     for infile in infiles:
         track = P.snip(infile, ".fastqc")
         all_files.extend(glob.glob(
-            os.path.join(track + "*_fastqc",
+            os.path.join(track + ".*_fastqc",
                          "fastqc_data.txt")))
 
     dfs = readqc.read_fastqc(

--- a/conda/environments/cgat-flow.yml
+++ b/conda/environments/cgat-flow.yml
@@ -14,7 +14,7 @@ channels:
 dependencies:
 # python dependencies
 - python >= 3.6
-- rpy2
+- rpy2 <= 2.9.4
 - tzlocal
 
 # exome.py


### PR DESCRIPTION
I was getting a bug where summarizeFastQC call was grabbing multiple samples if there was an overlapping name.

Expectation:
CondX_Sample99 matches CondX_Sample99.fastq.1_fastqc and CondX_Sample99.fastq.2_fastqc
CondX_Sample9 matches CondX_Sample9.fastq.1_fastqc, CondX_Sample9.fastq.2_fastqc

However, the previous glob call meant that CondX_Sample9 would also match CondX_Sample99.fastq.1_fastqc and CondX_Sample99.fastq.2_fastqc.

Changed the pattern to match the expectation above.
