### PR TITLE
Fixes for Bamstats

### DIFF
--- a/cgatpipelines/tasks/bamstats.py
+++ b/cgatpipelines/tasks/bamstats.py
@@ -84,7 +84,7 @@ def buildPicardInsertSizeStats(infile, outfile, genome_file,
     VALIDATION_STRINGENCY=SILENT
     >& %(outfile)s'''
 
-    P.run(statement, job_memory=picardmem)
+    P.run(statement)
 
 
 def addPseudoSequenceQuality(infile, outfile):

--- a/cgatpipelines/tasks/bamstats.py
+++ b/cgatpipelines/tasks/bamstats.py
@@ -719,9 +719,11 @@ def loadPicardHistogram(infiles, outfile, suffix, column,
     if len(xfiles) == 0:
         E.warn("no files for %s" % tablename)
         return
+
     header = ",".join([os.path.basename(x)
                        for x in xfiles])
     filenames = " ".join(["%s.%s" % (x, suffix) for x in xfiles])
+
     # there might be a variable number of columns in the tables
     # only take the first ignoring the rest
 

--- a/cgatpipelines/tasks/bamstats.py
+++ b/cgatpipelines/tasks/bamstats.py
@@ -719,11 +719,9 @@ def loadPicardHistogram(infiles, outfile, suffix, column,
     if len(xfiles) == 0:
         E.warn("no files for %s" % tablename)
         return
-
-    header = ",".join([P.snip(os.path.basename(x), pipeline_suffix)
+    header = ",".join([os.path.basename(x)
                        for x in xfiles])
     filenames = " ".join(["%s.%s" % (x, suffix) for x in xfiles])
-
     # there might be a variable number of columns in the tables
     # only take the first ignoring the rest
 

--- a/cgatpipelines/tools/pipeline_bamstats.py
+++ b/cgatpipelines/tools/pipeline_bamstats.py
@@ -304,25 +304,6 @@ def buildPicardStats(infiles, outfile):
                                        PICARD_MEMORY)
 
 
-@P.add_doc(bamstats.buildPicardInsertSizeStats)
-@transform(intBam,
-           regex("BamFiles.dir/(.*).bam$"),
-           add_inputs(os.path.join(PARAMS["genome_dir"],
-                                   PARAMS["genome"] + ".fa")),
-           r"Picard_stats.dir/\1.insert_stats")
-def buildPicardInserts(infiles, outfile):
-    ''' build Picard alignment stats '''
-    infile, reffile = infiles
-
-    if "transcriptome.dir" in infile:
-        reffile = "refcoding.fa"
-
-    bamstats.buildPicardInsertSizeStats(infile,
-                                        outfile,
-                                        reffile,
-                                        PICARD_MEMORY)
-
-
 @P.add_doc(bamstats.buildPicardDuplicationStats)
 @transform(intBam,
            regex("BamFiles.dir/(.*).bam$"),
@@ -778,12 +759,6 @@ def loadTranscriptProfile(infiles, outfile):
     bamstats.loadTranscriptProfile(infiles, outfile)
 
 
-@merge(buildPicardInserts, "picard_insert_metrics.csv")
-def mergePicardInsertMetrics(infiles, outfile):
-    ''' merge insert stats into a single table'''
-    bamstats.mergeInsertSize(infiles, outfile)
-
-
 @P.add_doc(bamstats.loadStrandSpecificity)
 @jobs_limit(PARAMS.get("jobs_limit_db", 1), "db")
 @follows(loadTranscriptProfile)
@@ -837,8 +812,7 @@ def views():
          loadExonValidation,
          loadPicardRnaSeqMetrics,
          loadTranscriptProfile,
-         loadStrandSpecificity,
-         mergePicardInsertMetrics)
+         loadStrandSpecificity)
 def full():
     '''a dummy task to run all tasks in the pipeline'''
     pass


### PR DESCRIPTION
- Removed PicardInserts functions in `pipeline_bamstats.py`, these are duplicated and already part of `CollectMultipleMetrics`. Incidentally, `CollectInsertMetrics` fails with memory errors whereas it `CollectMultipleMetrics` which includes it does not.
- Corrected header for `loadpicardhistogram` in `bamstats.py `- was empty in some circumstances resulting in function to fail.