### PR TITLE
{is} rnaseqqc repairs

### DIFF
--- a/cgatpipelines/tasks/mapping.py
+++ b/cgatpipelines/tasks/mapping.py
@@ -1314,7 +1314,7 @@ class SubsetHeads(Mapper):
             for n, ix in enumerate(range(0, len(limits))):
                 limit = limits[ix]
                 output_filename = output_prefix + "_%i.fastq.gz" % n
-                awk_cmd += '''{if (NR<%(limit)s) print |
+                awk_cmd += '''{if (NR<=%(limit)s) print |
                 "gzip > %(output_filename)s"};''' % locals()
             awk_cmd += '{if (NR>%s) {exit}};' % limits[-1]
 
@@ -1328,7 +1328,7 @@ class SubsetHeads(Mapper):
                     limit = limits[ix]
                     output_filename = output_prefix + \
                         "_%i.fastq.%i.gz" % (n, x + 1)
-                    awk_cmd += '''{if (NR<%(limit)s) print |
+                    awk_cmd += '''{if (NR<=%(limit)s) print |
                     "gzip > %(output_filename)s"};''' % locals()
                 awk_cmd += '{if (NR>%s) {exit}};' % limits[-1]
 

--- a/cgatpipelines/tools/pipeline_rnaseqqc.py
+++ b/cgatpipelines/tools/pipeline_rnaseqqc.py
@@ -1583,7 +1583,13 @@ def plotStrandednessSalmon(infile, outfile):
     a.ticklabel_format(style='plain')
     a.vlines(np.arange(-0.4, a.get_xlim()[1], len(tab)),
              a.get_ylim()[0], a.get_ylim()[1], lw=0.5)
-    a.set_xticks(np.arange(0 + len(tab) / 2, a.get_xlim()[1],
+
+    # There is one bar for each library type for each sample, if we divide
+    # the xaxis up into library types, with as many bars as samples in each
+    # division, then we want the first tick half way through the first
+    # divsion and then the space between ticks is the number of samples.
+    a.set_xticks(np.arange(len(tab)/2,
+                           len(tab)*len(counttab.columns),
                            len(tab)))
     a.set_xticklabels(counttab.columns)
     sns.despine()

--- a/cgatpipelines/tools/pipeline_rnaseqqc.py
+++ b/cgatpipelines/tools/pipeline_rnaseqqc.py
@@ -786,8 +786,8 @@ def runSalmon(infiles, outfiles):
 
 @collate(runSalmon,
          formatter(),
-        ["salmon.dir/transcripts.tsv.gz",
-        "salmon.dir/genes.tsv.gz"])
+         ["salmon.dir/transcripts.tsv.gz",
+          "salmon.dir/genes.tsv.gz"])
 def mergeSalmonResults(infiles, outfiles):
     ''' merge counts for alignment-based methods'''
 
@@ -1443,9 +1443,9 @@ def plotTopGenesHeatmap(outfile):
         ''' % locals())
 
         with localconverter(ro.default_converter + pandas2ri.converter):
-            r_intersection_pivot = ro.conversion.py2ri(intersection_pivot)
-            r_factors_df = ro.conversion.py2ri(factors_df)
-        
+            r_intersection_pivot = ro.conversion.py2rpy(intersection_pivot)
+            r_factors_df = ro.conversion.py2rpy(factors_df)
+
         plotHeatmap(r_intersection_pivot,
                     r_factors_df)
 
@@ -1469,7 +1469,7 @@ def plotExpression(outfile):
     # See RnaseqqcReport.ExpressionDistribution tracker
 
     dbh = P.connect()
-
+   
     statement = """
     SELECT * FROM transcripts"""
 
@@ -1501,12 +1501,12 @@ def plotExpression(outfile):
         f_colour_map = {f:
                         plt.cm.viridis((i % nlevels + 1)/float(nlevels))
                         for i, f in enumerate(factor_levels)}
-
+    
         for sname, subdf in df.groupby("sample_id"):
             factor_level = str(factor_df.factor_value.loc[sname])
             subdf.logTPM.plot(kind="density", color=f_colour_map[factor_level],
                               label=factor_level)
-
+            
         plt.title("TPM distribution by %(factor)s" % locals())
         plt.xlabel("log2 TPM")
         plt.ylabel("Density")
@@ -1516,8 +1516,7 @@ def plotExpression(outfile):
         plt.legend(handles=legend_lines)
         f.savefig(plotfile)
         plt.close()
-        
-
+ 
     iotools.touch_file(outfile)
 
 ###################################################################

--- a/cgatpipelines/tools/pipeline_rnaseqqc.py
+++ b/cgatpipelines/tools/pipeline_rnaseqqc.py
@@ -1287,7 +1287,7 @@ def summariseBias(infiles, outfile):
 
         temp_dict[attribute] = function
         means_df = df[["LogTPM", "sample_id"]].groupby(
-            ["sample_id", pd.qcut(df.ix[:, attribute], bins)])
+            ["sample_id", pd.qcut(df.loc[:, attribute], bins)])
 
         means_df = pd.DataFrame(means_df.agg(function))
         means_df.reset_index(inplace=True)
@@ -1372,8 +1372,7 @@ def plotTopGenesHeatmap(outfile):
 
     # set up the empty df
     intersection_df = pd.DataFrame(
-        index=range(0, len(exp_df.columns) **
-                    2 - len(exp_df.columns)),
+        index=[],
         columns=["sample1", "sample2", "intersection", "fraction"])
 
     # populate the df
@@ -1383,13 +1382,22 @@ def plotTopGenesHeatmap(outfile):
         s2_genes = top_genes[col2]
         intersection = set(s1_genes).intersection(set(s2_genes))
         fraction = len(intersection) / float(top_n)
-        intersection_df.ix[n] = [col1, col2, len(intersection), fraction]
+        intersection_df = intersection_df.append(
+            pd.Series({"sample1": col1,
+                       "sample2": col2,
+                       "intersection": len(intersection),
+                       "fraction": fraction}),
+            ignore_index=True)
         n += 1
 
         # if the samples are different, calculate the reverse intersection too
         if col1 != col2:
-            intersection_df.ix[n] = [col2, col1,
-                                     len(intersection), fraction]
+            intersection_df = intersection_df.append(
+                pd.Series({"sample1": col2,
+                           "sample2": col1,
+                           "intersection": len(intersection),
+                           "fraction": fraction}),
+                ignore_index=True)
             n += 1
 
 

--- a/cgatpipelines/tools/pipeline_rnaseqqc.py
+++ b/cgatpipelines/tools/pipeline_rnaseqqc.py
@@ -1228,7 +1228,7 @@ def characteriseTranscripts(infile, outfile):
 
     statement = '''
     cat %(infile)s | cgat fasta2table
-    --split-fasta-identifier --section=na;dn;length -v 0
+    --split-fasta-identifier --section na dn length -L %(outfile)s.log
     | gzip > %(outfile)s'''
 
     P.run(statement)

--- a/cgatpipelines/tools/pipeline_rnaseqqc.py
+++ b/cgatpipelines/tools/pipeline_rnaseqqc.py
@@ -180,6 +180,7 @@ import itertools
 from scipy.stats import linregress
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
+import matplotlib.lines as mlines
 import seaborn as sns
 
 from rpy2.robjects import r as R

--- a/cgatpipelines/tools/pipeline_rnaseqqc.py
+++ b/cgatpipelines/tools/pipeline_rnaseqqc.py
@@ -750,7 +750,7 @@ def indexForSalmon(infile, outfile):
 
     statement = '''
     salmon index -k %(salmon_kmer)i -t %(infile)s -i %(outfile)s >& %(outfile)s.log'''
-    P.run(statement, job_memory="8G", job_condaenv="salmon")
+    P.run(statement, job_memory="8G")
 
 
 @collate(SEQUENCEFILES,

--- a/cgatpipelines/tools/pipeline_rnaseqqc.py
+++ b/cgatpipelines/tools/pipeline_rnaseqqc.py
@@ -785,7 +785,7 @@ def runSalmon(infiles, outfiles):
 
 
 @collate(runSalmon,
-        regex(".*"),
+         formatter(),
         ["salmon.dir/transcripts.tsv.gz",
         "salmon.dir/genes.tsv.gz"])
 def mergeSalmonResults(infiles, outfiles):
@@ -927,7 +927,7 @@ def plotSalmonSaturation(infiles, outfile):
     # Patro's Wasabi R package for making salmon output
     # compatable with sleuth
     minfo <- rjson::fromJSON(file=file.path(
-      Path, 'highest_counts_subset_9', "aux", "meta_info.json"))
+      Path, 'highest_counts_subset_9', "aux_info", "meta_info.json"))
 
     numBoot <- minfo$num_bootstraps
 
@@ -938,12 +938,12 @@ def plotSalmonSaturation(infiles, outfile):
 
     for (ix in seq(0,9,1)){
       bootCon <- gzcon(file(file.path(
-        Path, paste0('highest_counts_subset_', ix), 'aux',
+        Path, paste0('highest_counts_subset_', ix), 'aux_info',
                      'bootstrap', 'bootstraps.gz'), "rb"))
 
       # read in binary data
       boots <- readBin(bootCon, "double",
-                       n = minfo$num_targets * minfo$num_bootstraps)
+                       n = minfo$num_valid_targets * minfo$num_bootstraps)
       close(bootCon)
 
       # turn data into dataframe
@@ -1007,7 +1007,7 @@ def plotSalmonSaturation(infiles, outfile):
     point_df = read.table(
       file.path(Path, paste0('highest_counts_subset_', ix), "quant.sf"),
       sep="\t", header=T, row.names=1)
-`
+
     tpm_est[[paste0("sample_", ix)]] = (
       abs(point_df$TPM - ref_point_df$TPM) / ref_point_df$TPM)
     }
@@ -1538,7 +1538,7 @@ def checkStrandednessSalmon(infiles, outfile):
                        "compatible_fragment_ratio",
                        "num_compatible_fragments",
                        "num_assigned_fragments",
-                       "num_frags_with_consistent_mappings",
+                       "num_frags_with_concordant_consistent_mappings",
                        "num_frags_with_inconsistent_or_orphan_mappings",
                        "MSF", "OSF", "ISF", "MSR",
                        "OSR", "ISR", "SF", "SR",

--- a/conda/environments/cgat-flow-pipelines.yml
+++ b/conda/environments/cgat-flow-pipelines.yml
@@ -54,6 +54,7 @@ dependencies:
 - r-snow
 - r-stringr
 - r-venndiagram
+- r-rjson
 - bioconductor-biomart
 - bioconductor-hpar
 - bioconductor-edger


### PR DESCRIPTION
A collection of small changes neccesary to get pipeline_rnaseqqc running on our system. 

**One of these changes is breaking and requires rpy2 version >3**

---
Alters cgatpipelines.tasks.mapping.SubsetHeads so that it uses NR<= rather than NR< in the subsetting code, as this was missing the final line from FASTA records.

This is still *very* slow on our systems. I'm not sure why, but it feels like we should be able to do better.

See issue #145 

---
Adds r-rjson to the conda env, as required by rnaseqqc
see issue #147 

---
Switch plotExpression to matplotlib from rpy2/ggplot.
fixes problems arrising from changes in rpy2 to just avoid using rpy2.
*This patch will make the pipeline work with both old and new rpy2*

---
 Salmon compatibility changes 

Changes to make rnaseqqc compatible with salmon > 1.0, mostly inthe location and format of metadata, reports and logs.
Removes specification for a seperate salmon enbironment

---
fasta2table section specification

Changes call to fasta2table so that section names are seperated
with space rather than ;. This is neccessary because of change to
argparse from optparse, but unclear if it is compatible with
galaxy?

Also needed to remove `=`.

See issue #144

---
Changes for compatibility with modern pandas

---
Setting xlim in plotStrandednessSalmon 

Changes code for setting the x limits and tick locations in
plotStandednessSalmon. Previously this relied on the automatic
setting of the upper x limit in exactly the correct place, but this
was often wrong.

---
rpy2 >3.0 changes

This change makes rnaseqqc compatible with rpy2 3.1. That
probably means that it will make it incompatible with rpy3 <3.
A decision will need to be made whether to support this.