### PR TITLE
Cutadapt 3.4 no longer accepts --format.

### DIFF
--- a/cgatpipelines/tasks/preprocess.py
+++ b/cgatpipelines/tasks/preprocess.py
@@ -532,13 +532,6 @@ class Cutadapt(ProcessTool):
             in1, in2 = infiles
             out1, out2 = outfiles
 
-            if "fastq" in in1:
-                format = "--format=fastq"
-            elif "fasta" in in1:
-                format = "--format=fasta"
-            else:
-                format = ""
-
             untrimmed_output1, untrimmed_output2 = \
                 [i.replace(".fast", "_untrimmed.fast")
                  for i in infiles]
@@ -550,7 +543,7 @@ class Cutadapt(ProcessTool):
 
             cmds.append('''
             cutadapt %(processing_options)s %(in1)s %(in2)s
-                     -p %(out2)s -o %(out1)s %(format)s
+                     -p %(out2)s -o %(out1)s
             2>> %(output_prefix)s.log; ''' % locals())
 
             if untrimmed:


### PR DESCRIPTION
Modern versions of cutadapt no longer take a `--format` arugment. This has been replaced with automatic detection. preprocess.py was hardcoded to add this switch, which was causing the readqc pipeline to fail. I have just removed the format checking code. 

