### PR TITLE
Fix buildJunctions in mapping pipeline

### DIFF
--- a/cgatpipelines/tools/pipeline_mapping.py
+++ b/cgatpipelines/tools/pipeline_mapping.py
@@ -619,6 +619,8 @@ def buildJunctions(infile, outfile):
     for gffs in GTF.transcript_iterator(
             GTF.iterator(iotools.open_file(infile, "r"))):
 
+        gffs = [e for e in gffs if e.feature == "exon"]
+        
         gffs.sort(key=lambda x: x.start)
         end = gffs[0].end
         for gff in gffs[1:]:


### PR DESCRIPTION
Currently buildJunctions erroneously uses all features in a gff files, not just exons. This leads not just incorrect junctions, but an invalid file. 

See #157 