### PR TITLE
Regex in pipeline_genesets.py

### DIFF
--- a/cgatpipelines/tools/pipeline_genesets.py
+++ b/cgatpipelines/tools/pipeline_genesets.py
@@ -606,7 +606,7 @@ def buildUCSCGeneSet(infile, outfile):
 
 
 @transform(buildUCSCGeneSet,
-           regex(".*.gtf.gz"),
+           regex(".*\.gtf.gz"),
            PARAMS['interface_geneset_cds_gtf'])
 def buildCdsTranscript(infile, outfile):
     '''
@@ -638,7 +638,7 @@ def buildCdsTranscript(infile, outfile):
 
 
 @transform(buildUCSCGeneSet,
-           regex("*.gtf.gz"),
+           regex(".*\.gtf.gz"),
            PARAMS['interface_geneset_exons_gtf'])
 def buildExonTranscript(infile, outfile):
     '''
@@ -1153,7 +1153,7 @@ def identifyProteinCodingGenes(outfile):
 
 
 @transform(buildUCSCGeneSet,
-           regex(".*.gtf.gz"),
+           regex(".*\.gtf.gz"),
            PARAMS['interface_utr_all_gtf'])
 def buildUtrGeneSet(infile, outfile):
 
@@ -1163,7 +1163,7 @@ def buildUtrGeneSet(infile, outfile):
 
 
 @transform(buildFlatGeneSet,
-           regex(".*.gtf.gz"),
+           regex(".*\.gtf.gz"),
            add_inputs(identifyProteinCodingGenes,
                       buildExonTranscript),
            PARAMS['interface_geneset_intron_gtf'])


### PR DESCRIPTION
A previous change from suffix to regex in some decorators left `regex("*.gtf.gz")`, which is not a valid regex. Edited to `regex(".*\.gtf.gz")`